### PR TITLE
Update gmwrapper.py

### DIFF
--- a/gmwrapper.py
+++ b/gmwrapper.py
@@ -264,7 +264,7 @@ class _Base(object):
 
 		for path in paths:
 			if not isinstance(path, unicode):
-				path = path.decode('utf8')
+				path = path.encode('utf8')
 
 			if os.path.isdir(path):
 				for dirpath, dirnames, filenames in os.walk(path):


### PR DESCRIPTION
Modified path.decode('utf8') to path.encode('utf-8')

This fixed a problem I had:
```
...

 File "/home/transmission/gmusicapi-scripts/gmwrapper.py", line 270, in get_local_songs
    for dirpath, dirnames, filenames in os.walk(path):
  File "/usr/lib/python2.7/os.py", line 296, in walk
    for x in walk(new_path, topdown, onerror, followlinks):
  File "/usr/lib/python2.7/os.py", line 296, in walk
    for x in walk(new_path, topdown, onerror, followlinks):
  File "/usr/lib/python2.7/os.py", line 286, in walk
    if isdir(join(top, name)):
  File "/usr/lib/python2.7/genericpath.py", line 41, in isdir
    st = os.stat(s)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 106: ordinal not in range(128)
```